### PR TITLE
検索エンジンのクローラーで表示可能なように修正

### DIFF
--- a/app/frontend/components/Score/SoundControl/index.js
+++ b/app/frontend/components/Score/SoundControl/index.js
@@ -21,9 +21,11 @@ export default class SoundControl extends Component {
     Transport.stop()
     Transport.cancel()
     Transport.clear()
-    Tone.context.close()
-    Tone.context = new AudioContext()
-    StartAudioContext(Tone.context) // https://github.com/Tonejs/Tone.js/issues/341
+    if (Tone.context.close) { // Google Crawler 対策
+      Tone.context.close()
+      Tone.context = new AudioContext()
+      StartAudioContext(Tone.context) // https://github.com/Tonejs/Tone.js/issues/341
+    }
 
     // Tone.context.latencyHint = LATENCY_HINT
     // Tone.context.updateInterval = UPDATE_INTERVAL


### PR DESCRIPTION
#41 

## スクリーンショット
* `Fetch as Google` でページを確認しても、なぜか何も表示されない状態だった
![image](https://user-images.githubusercontent.com/16236972/41202948-acfb7ca0-6d0b-11e8-8318-44b3ef18f74e.png)

## 修正
* ブラウザの console にエラーが出力されていた
* Tone.js の `Tone.context.close()` が undefined になって機能していなかったのが原因