### PR TITLE
Google 認証で JWT::InvalidIssuerError になるのを解消

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -261,7 +261,7 @@ Devise.setup do |config|
       secure_image_url: true,
       image_size:       "large"
     }
-  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
+  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], skip_jwt: true
   config.omniauth :tumblr, ENV["TUMBLR_KEY"], ENV["TUMBLR_SECRET"]
   config.omniauth :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"], scope: "user,repo"
 


### PR DESCRIPTION
## 修正
* Google で認証しようとすると JWT::InvalidIssuerError が出ていた。本番移行直後は大丈夫だったのになぜ…
* JWT を skip

## その他
* 参考: https://qiita.com/takuchan9104/items/1b588e125f8a1e0c7605