### PR TITLE
session_store から redis を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,10 +57,6 @@ gem 'rmagick'
 gem 'impressionist', git: 'https://github.com/charlotte-ruby/impressionist.git', ref: '46a582ff8cd3496da64f174b30b91f9d97e86643'
 gem 'counter_culture', '~> 1.8'
 
-# Session
-gem 'redis'
-gem 'redis-rails'
-
 # Backup
 gem 'dropbox_api'
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,6 @@ GEM
     chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
     counter_culture (1.12.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -281,8 +280,6 @@ GEM
     rack (2.2.9)
     rack-proxy (0.7.6)
       rack
-    rack-session (1.0.2)
-      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (6.1.7.3)
@@ -332,26 +329,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.3.0)
-      redis-client (>= 0.22.0)
-    redis-actionpack (5.4.0)
-      actionpack (>= 5, < 8)
-      redis-rack (>= 2.1.0, < 4)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.3.0)
-      activesupport (>= 3, < 8)
-      redis-store (>= 1.3, < 2)
-    redis-client (0.22.2)
-      connection_pool
-    redis-rack (3.0.0)
-      rack-session (>= 0.2.0)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.11.0)
-      redis (>= 4, < 6)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -487,8 +464,6 @@ DEPENDENCIES
   rails_admin
   rails_admin-i18n
   ransack
-  redis
-  redis-rails
   rmagick
   sassc-rails
   selenium-webdriver

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,0 @@
-$redis = Redis.new(url: ENV['REDIS_URL'], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,0 @@
-Rechord::Application.config.session_store :redis_store,
-                                          servers: ENV['REDIS_URL'],
-                                          expire_after: 20.years,
-                                          key: "_#{Rails.application.class.module_parent_name.downcase}_session",
-                                          threadsafe: false,
-                                          ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }


### PR DESCRIPTION
#166 で解消できなかったため。
元々特に意味なく設定してたのでこのタイミングで削除する。
一度全員ログアウトされてしまうのは申し訳ないけど仕方がない…